### PR TITLE
Add feature of Jadwalin module to be set by an interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,20 @@ $ yarn install jadwalin
 
 ```javascript
 const jadwalin = require('jadwalin');
-const task = () => console.log('selamat pagi hayati');
-jadwalin(task).setiap('7:30');
+
+const task1 = () => {
+  const now = new Date();
+  console.log(now + ': selamat pagi hayati 1');
+};
+
+const task2 = () => {
+  const now = new Date();
+  console.log(now + ': selamat pagi hayati 2');
+};
+
+const scheduler1 = new jadwalin(task1);
+const scheduler2 = new jadwalin(task2);
+
+scheduler1.setiap(2000);
+scheduler2.pada('3:28');
 ```

--- a/example.js
+++ b/example.js
@@ -1,0 +1,17 @@
+const jadwalin = require('./');
+
+const task1 = () => {
+  const now = new Date();
+  console.log(now + ': selamat pagi hayati 1');
+};
+
+const task2 = () => {
+  const now = new Date();
+  console.log(now + ': selamat pagi hayati 2');
+};
+
+const scheduler1 = new jadwalin(task1);
+const scheduler2 = new jadwalin(task2);
+
+scheduler1.setiap(2000);
+scheduler2.pada('3:28');

--- a/index.js
+++ b/index.js
@@ -1,41 +1,68 @@
-const intervals = {};
-const date = new Date();
-let ticker;
-const startTicker = () => {
-  ticker = setInterval(() => {
-    const date = new Date();
-    const hour = date.getHours();
-    const minute = date.getMinutes();
-    const time = `${hour}:${minute}`;
 
-    if (intervals[time]) {
-      intervals[time]();
-    }
-  }, 60000);
-};
-
-// Make sure we start the clock precisely ON the 0th millisecond
-setTimeout(() => {
-  startTicker();
-}, Math.ceil((+date / 1000) * 1000 - +date));
-
-const jadwalin = (callback = null) => {
+function jadwalin(callback = null) {
+  this.ticker = null;
   this.callback = callback;
+  this.hour = null;
+  this.minute = null;
+  this.isInterval = false;
+  
+  this.initTicker = (msInterval = 60000) => {
+    if (this.ticker !== null) {
+      clearInterval(this.ticker);
+    }
+    
+    const initDate = new Date();
+    // Make sure we start the clock precisely ON the 0th millisecond
+    setTimeout(() => {
+      this.startTicker(msInterval);
+    }, Math.ceil((+initDate / 1000) * 1000 - +initDate));
+  };
+
+  this.startTicker = (msInterval) => {
+    this.ticker = setInterval(() => {
+      const date = new Date();
+      const hour = date.getHours();
+      const minute = date.getMinutes();
+  
+      if (this.hour === hour && this.minute === minute) {
+        this.callback();
+      }
+
+      if (this.isInterval) {
+        this.callback();
+      }
+    }, msInterval);
+  };
+
   return {
-    destroy: () => clearInterval(ticker),
-    setiap: (time) => {
+    destroy: () => clearInterval(this.ticker),
+    pada: (time) => {
+      if (this.isInterval)
+        throw new Error('pada() function cannot be used in conjunction with setiap() function');
+
       if (typeof time !== 'string')
         throw new Error('time should be string with format hh:mm');
 
       const splittedTime = time.split(':');
       const hour = parseInt(splittedTime[0]);
       const minute = parseInt(splittedTime[1]);
-
+        
       if (isNaN(hour) || isNaN(minute))
         throw new Error('time should be string with format hh:mm');
+        
+      this.hour = hour;
+      this.minute = minute;
+      this.initTicker();
+    },
+    setiap: (ms) => {
+      if (this.hour || this.minute)
+        throw new Error('setiap() function cannot be used in conjunction with pada() function');
 
-      const normalizedTime = `${hour}:${minute}`;
-      intervals[normalizedTime] = this.callback;
+      if (typeof ms !== 'number')
+        throw new Error('arg should be a number in milisecond');
+
+      this.isInterval = true;
+      this.initTicker(ms);
     }
   };
 };


### PR DESCRIPTION
## Summary
`setiap(date: string) // previous version` become `pada(date: string)`
new function: `setiap(milisecond: number)`

Add a new functionality of Jadwalin module which is an interval. `setiap()` cannot be used in conjunction with `pada()` because it uses same JS interval method. That's why this PR change the Jadwalin module to be an object that requires constructor.

example usage:
```
const jadwalin = require('jadwalin');

const task1 = () => {
  const now = new Date();
  console.log(now + ': selamat pagi hayati 1');
};

const task2 = () => {
  const now = new Date();
  console.log(now + ': selamat pagi hayati 2');
};

const scheduler1 = new jadwalin(task1);
const scheduler2 = new jadwalin(task2);

scheduler1.setiap(2000);
scheduler2.pada('3:28');
```